### PR TITLE
build: add ARM cross-compilation toolchain for CGO builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,10 @@ jobs:
       #   run: |
       #     sudo apt-get update
       #     sudo apt-get install -y libgpgme-dev
+      - name: Install ARM cross-compilation toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23.0'
@@ -114,10 +118,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install system dependencies
+      # - name: Install system dependencies
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y libgpgme-dev
+      - name: Install ARM cross-compilation toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgpgme-dev
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23.0'

--- a/.goreleaser-potctl.yml
+++ b/.goreleaser-potctl.yml
@@ -70,17 +70,48 @@ builds:
       - -s -w -X "github.com/datasance/potctl/pkg/util.agentVersion=3.5.6"
       - -s -w -X "github.com/datasance/potctl/pkg/util.repo=ghcr.io/datasance"
 
-  - id: build_linux_arm
+  - id: build_linux_arm64
     binary: potctl
     main: ./cmd/potctl/
     goos:
       - linux
     goarch:
       - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_ENABLED=1
+    flags:
+      - -v
+      - -tags=containers_image_openpgp,exclude_graphdriver_btrfs
+    ldflags:
+      - -s -w -X "github.com/datasance/potctl/pkg/util.versionNumber=v{{.Version}}"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.commit={{ .ShortCommit }}"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.date={{.Date}}"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.platform={{.Os}}/{{.Arch}}"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.operatorTag=3.5.4"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.routerAdaptorTag=3.5.2"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.routerTag=3.5.2"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.controllerTag=3.5.10"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.agentTag=3.5.6"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.controllerVersion=3.5.10"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.agentVersion=3.5.6"
+      - -s -w -X "github.com/datasance/potctl/pkg/util.repo=ghcr.io/datasance"
+
+  - id: build_linux_arm
+    binary: potctl
+    main: ./cmd/potctl/
+    goos:
+      - linux
+    goarch:
       - arm
     goarm:
       - 6
       - 7
+    env:
+      - CC=arm-linux-gnueabihf-gcc
+      - CXX=arm-linux-gnueabihf-g++
+      - CGO_ENABLED=1
     flags:
       - -v
       - -tags=containers_image_openpgp,exclude_graphdriver_btrfs
@@ -128,6 +159,7 @@ archives:
     id: linux
     ids:
       - build_linux_amd64
+      - build_linux_arm64
       - build_linux_arm
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     formats: [ 'tar.gz' ]
@@ -205,7 +237,7 @@ brews:
 
 nfpms:
   -
-    ids: ['build_linux_amd64', 'build_linux_arm']
+    ids: ['build_linux_amd64', 'build_linux_arm64', 'build_linux_arm']
     homepage:  "https://github.com/datasance/potctl"
     description: CLI for managing Datasance PoT's Distributed Edge Compute clusters
     maintainer: Datasance Teknoloji A.S.


### PR DESCRIPTION
Split Linux builds and add cross-compilation toolchain to fix ARM64 build errors. ARM builds use dynamic linking with proper CC/CXX environment variables set for each architecture.

- Split into build_linux_amd64 (static), build_linux_arm64, build_linux_arm
- Install gcc-aarch64-linux-gnu and gcc-arm-linux-gnueabihf in CI
- Set CC=aarch64-linux-gnu-gcc for ARM64, CC=arm-linux-gnueabihf-gcc for ARM
- Remove static linking from ARM builds (cross-compilation complexity)

Fixes: ARM64 assembler errors during CGO cross-compilation