### PR TITLE
build: disable CGO for macOS builds

### DIFF
--- a/.goreleaser-potctl.yml
+++ b/.goreleaser-potctl.yml
@@ -23,6 +23,7 @@ builds:
   - id: build_macos
     binary: potctl
     env:
+      - CGO_ENABLED=0
     main: ./cmd/potctl/main.go
     goos:
       - darwin


### PR DESCRIPTION
Disable CGO for macOS builds to fix cross-compilation errors. macOS cross-compilation with CGO from Linux CI requires macOS SDK which isn't available. With build tags, containers/image works without CGO.

Fixes: macOS clang cross-compilation error